### PR TITLE
Rename things named `Ajax` to `AdminAjax`

### DIFF
--- a/brochure_request_cpt.php
+++ b/brochure_request_cpt.php
@@ -8,7 +8,7 @@
 
 require_once plugin_dir_path(__FILE__) . 'src/classes/Activation.php';
 require_once plugin_dir_path(__FILE__) . 'src/classes/AdminUI.php';
-require_once plugin_dir_path(__FILE__) . 'src/classes/Ajax.php';
+require_once plugin_dir_path(__FILE__) . 'src/classes/AdminAjax.php';
 require_once plugin_dir_path(__FILE__) . 'src/classes/Brochure.php';
 require_once plugin_dir_path(__FILE__) . 'src/classes/Constants.php';
 require_once plugin_dir_path(__FILE__) . 'src/classes/CustomPostType.php';
@@ -20,7 +20,7 @@ require_once plugin_dir_path(__FILE__) . 'src/classes/TaxonomyRegistrar.php';
 use JB\BRC;
 use JB\BRC\Activation;
 use JB\BRC\AdminUI;
-use JB\BRC\Ajax;
+use JB\BRC\AdminAjax;
 use JB\BRC\Brochure;
 use JB\BRC\Constants;
 use JB\BRC\CustomPostType;
@@ -31,7 +31,7 @@ use JB\BRC\TaxonomyRegistrar;
 
 add_action('init', function() {
   new AdminUI();
-  new Ajax();
+  new AdminAjax();
   new CustomPostType();
   new Sidebar();
 });

--- a/src/classes/AdminAjax.php
+++ b/src/classes/AdminAjax.php
@@ -5,7 +5,7 @@ namespace JB\BRC;
 use JB\BRC\Constants;
 use JB\BRC\Helpers;
 
-class Ajax {
+class AdminAjax {
 
   public function __construct() {
     add_action('wp_ajax_unset_brochure', array($this, 'unset_brochure'));

--- a/src/classes/AdminUI.php
+++ b/src/classes/AdminUI.php
@@ -22,7 +22,7 @@ class AdminUI {
       $this->set_current_post_id();
       $this->enqueue_css();
       $this->enqueue_media();
-      $this->enqueue_ajax();
+      $this->enqueue_admin_ajax();
     }
   }
 
@@ -104,27 +104,28 @@ class AdminUI {
     );
   }
 
-  private function enqueue_ajax() {
-    $ajax_js_args = $this->ajax_js_args();
-    $ajax_js_id = $ajax_js_args[0];
-    $ajax_js_localization_args = $this->ajax_js_localization($ajax_js_id);
+  private function enqueue_admin_ajax() {
+    $admin_ajax_js_args = $this->admin_ajax_js_args();
+    $admin_ajax_js_id = $admin_ajax_js_args[0];
+    $admin_ajax_js_localization_args =
+      $this->admin_ajax_js_localization($admin_ajax_js_id);
 
-    wp_register_script(...$ajax_js_args);
-    wp_localize_script(...$ajax_js_localization_args);
-    wp_enqueue_script($ajax_js_id);
+    wp_register_script(...$admin_ajax_js_args);
+    wp_localize_script(...$admin_ajax_js_localization_args);
+    wp_enqueue_script($admin_ajax_js_id);
   }
 
-  private function ajax_js_args() {
+  private function admin_ajax_js_args() {
     return array(
-      Constants::$AJAX_JS_ID,                 // Unique string identifier
-      plugins_url(Constants::$AJAX_JS_PATH),  // Source URL
-      array('jquery'),                        // Dependencies
+      Constants::$ADMIN_AJAX_JS_ID,                 // Unique string identifier
+      plugins_url(Constants::$ADMIN_AJAX_JS_PATH),  // Source URL
+      array('jquery'),                              // Dependencies
       null,                                   // Version (null = not versioned)
       false                                   // Load script in footer
     );
   }
 
-  private function ajax_js_localization($script_id) {
+  private function admin_ajax_js_localization($script_id) {
     global $post;
 
     return array(
@@ -132,8 +133,8 @@ class AdminUI {
       'ajaxLocalData',
       array(
         'ajaxURL' => admin_url('admin-ajax.php'),
-        'currentFile' => Constants::$AJAX_JS_CURRENT_FILE_ID,
-        'deleteButton' => Constants::$AJAX_JS_DELETE_BUTTON_ID,
+        'currentFile' => Constants::$ADMIN_AJAX_JS_CURRENT_FILE_ID,
+        'deleteButton' => Constants::$ADMIN_AJAX_JS_DELETE_BUTTON_ID,
         'current_post_id' => $post->ID
       )
     );

--- a/src/classes/Constants.php
+++ b/src/classes/Constants.php
@@ -33,10 +33,10 @@ class Constants {
   public static $MEDIA_FRAME_BUTTON_TEXT = 'Use this brochure';
 
   // AJAX
-  public static $AJAX_JS_ID = 'brc_ajax_js';
-  public static $AJAX_JS_PATH = 'brochure_request_cpt/src/js/ajax.js';
-  public static $AJAX_JS_CURRENT_FILE_ID = 'brc-current-file-url';
-  public static $AJAX_JS_DELETE_BUTTON_ID = 'brc-delete-button';
+  public static $ADMIN_AJAX_JS_ID = 'brc_ajax_js';
+  public static $ADMIN_AJAX_JS_PATH = 'brochure_request_cpt/src/js/ajax.js';
+  public static $ADMIN_AJAX_JS_CURRENT_FILE_ID = 'brc-current-file-url';
+  public static $ADMIN_AJAX_JS_DELETE_BUTTON_ID = 'brc-delete-button';
 
 }
 

--- a/src/classes/Metabox.php
+++ b/src/classes/Metabox.php
@@ -33,8 +33,8 @@ class Metabox {
     $launch_button_id = Constants::$MEDIA_JS_LAUNCH_BUTTON_ID;
     $preview_link_id = Constants::$MEDIA_JS_PREVIEW_LINK_ID;
     $clear_button_id = Constants::$MEDIA_JS_CLEAR_BUTTON_ID;
-    $current_file_id = Constants::$AJAX_JS_CURRENT_FILE_ID;
-    $delete_button_id = Constants::$AJAX_JS_DELETE_BUTTON_ID;
+    $current_file_id = Constants::$ADMIN_AJAX_JS_CURRENT_FILE_ID;
+    $delete_button_id = Constants::$ADMIN_AJAX_JS_DELETE_BUTTON_ID;
     $delete_button_enabled = ($meta_data ? "enabled" : "disabled");
 
     ob_start();


### PR DESCRIPTION
The original naive implementation of this plugin assumed that only one
class would be relying on AJAX. Working under that assumption, I had
named files, classes, variables, etc. in a non-specific way. For
example, the AJAX requests were being made by a class called `Ajax`.

This practice has caused a tight coupling between the `Ajax` class and
the `AdminUI` class. This is a problem because the next feature that
will be built is an AJAX filter module that needs to make AJAX requests
from the public side of the app.

The solution to this problem that I've chosen to go with is another
fairly naive approach. I decided to simply rename anything that had
"AJAX" in the name. For example, the constant that was originally named
`$AJAX_JS_ID` has become `$ADMIN_AJAX_JS_ID`. By appending the `ADMIN`
prefix, the existing code will at least look differently than the new
AJAX code that will be coming in a subsequent commit.

This approach has some obvious drawbacks, *namely*, much of the AJAX
logic will be duplicated after the filter is implemented on the front
end. Depending on if/how the requirements for the filter change in the
future, it may be worthwhile to extract the lower-level aspects of the
AJAX requests into a new object, and share that object around to
whichever classes need to make AJAX calls.

Another drawback is that the renaming strategy doesn't actually do
anything to decouple the `AdminAjax` (formerly just `Ajax`) and the
`AdminUI` classes. One possible approach might be to extract a `Post`
object that is composed of the `AdminAjax` and `AdminUI` classes. The
`Post` object might even be a more appropriate place for the AJAX code
that updates the "Edit Brochure" page.