### PR TITLE
Remove calls to get header and footer

### DIFF
--- a/src/templates/shortcode-brochure.php
+++ b/src/templates/shortcode-brochure.php
@@ -1,7 +1,7 @@
 <?php
 /* Outputs the Insights Videos in an archive layout. */
+?>
 
-get_header(); ?>
 <div class="container">
   <div class="content-wrapper">
     <div class="row">
@@ -24,5 +24,4 @@ get_header(); ?>
     </div>
   </div>
 </div>
-<?php get_footer(); ?>
 


### PR DESCRIPTION
Fixes a bug that attempted to certain page templates unnecessarily,
including the header template and footer template.