### PR TITLE
Fix URL string after AJAX requests

### DIFF
--- a/assets/javascripts/filterAjax.js
+++ b/assets/javascripts/filterAjax.js
@@ -17,7 +17,6 @@
 
     function parseFilters(changedForm) {
       var spinnerContainer = $("#brc-spinner-container");
-      var postsContainer = $("#posts-container");
 
       var brandsForm = $("#" + ajaxLocalData.brandsForm);
       var productCategoriesForm = $("#" + ajaxLocalData.productCategoriesForm);
@@ -37,21 +36,54 @@
           product_term_id: productTermID
         },
         success: function(response) {
-          $(document.body).trigger('post-load');
           removeSpinner(spinnerContainer);
-          postsContainer.html(response);
+          insertPosts(response.html);
+          updateBrowserState(response);
         }
       });
+    }
+
+    function insertPosts(postsHtml) {
+      var postsContainer = $("#posts-container");
+      postsContainer.html(postsHtml);
+
+      // See codex.wordpress.org/AJAX_in_Plugins#The_post-load_JavaScript_Event
+      // for more info about triggering the 'post-load' event
+      $(document.body).trigger('post-load');
+    }
+
+    function updateBrowserState(ajaxResponse) {
+      document.title = ajaxResponse.pageTitle;
+
+      var currentState = {
+        "html": ajaxResponse.html,
+        "title": ajaxResponse.pageTitle,
+        "url": ajaxResponse.url
+      };
+
+      window.history.pushState(currentState, "", ajaxResponse.url);
     }
 
     function addSpinner(container) {
       var spinner = container.children('.spinner');
 
       if (!spinnerIsRunning(spinner)) {
-        !spinner.length;
         spinner = buildSpinner(container);
         animateSpinner(spinner, 'add');
       }
+    }
+
+    function spinnerIsRunning(spinner) {
+      var exists = spinner.length ? true : false;
+      var notBeingRemoved = isBeingRemoved(spinner);
+
+      return (exists && notBeingRemoved);
+    }
+
+    function isBeingRemoved(element) {
+      var beingRemoved = element.hasClass('spinner-remove') ? true : false;
+
+      return !beingRemoved;
     }
 
     function buildSpinner(container) {
@@ -61,16 +93,9 @@
       return spinner;
     }
 
-    function spinnerIsRunning(spinner) {
-      var hasLength = spinner.length ? true : false;
-      var notBeingRemoved = !spinner.hasClass('spinner-remove') ? true : false;
-
-      return (hasLength && notBeingRemoved);
-    }
-
     function removeSpinner(container, success) {
       var spinner = container.children('.spinner');
-      spinner.length;
+
       animateSpinner(spinner, 'remove', success);
     }
 
@@ -86,7 +111,6 @@
         success && success();
       }, parseFloat(container.css('animation-duration')) * 1000));
     }
-
   });
 
 })(jQuery);

--- a/src/classes/FilterAjax.php
+++ b/src/classes/FilterAjax.php
@@ -26,10 +26,29 @@ class FilterAjax {
   }
 
   public function brc_filter_brochures() {
+    $html = $this->build_markup();
+    $page_title = get_bloginfo('name');
+    $url = '/' . $this->url_base;
+
+    $response = array(
+      'html' => $html,
+      'title' => $page_title,
+      'url' => $url
+    );
+
+    wp_send_json($response);
+  }
+
+  private function build_markup() {
+    ob_start();
+
     $this->set_term_ids();
     $this->build_filtered_posts();
 
-    wp_die();
+    $output = ob_get_contents();
+    ob_end_clean();
+
+    return $output;
   }
 
   private function set_term_ids() {


### PR DESCRIPTION
This enhancement rewrites the current URL after filtering brochures.

A user might land on the brochure page and click through several pages
of brochures. For example, on page 3, the URL might look like this:

  `https://www.clearymillwork.com/resources/brochures/pages/3`

If at that point, the user decides to use a filter, an AJAX request is
made. Once the data is returned, the page contains the first page of
brochures - but the URL still appears to indicate page 3.

Now, the URL of the base page is returned along with the brochure data,
and the browser state is updated to reflect the page content.