### PR TITLE
Add clear button, other enhancements

### DIFF
--- a/assets/javascripts/requestAjax.js
+++ b/assets/javascripts/requestAjax.js
@@ -212,9 +212,14 @@
       $("#brc-ship-zip-code").val(userData.zipCode);
     }
 
-
     $("body").on("touchstart click", ".brc-request-single", function() {
       $(this).toggleRequest();
+    });
+
+    $("body").on("touchstart click", "#brc-clear-all", function() {
+      $(".brc-request-single").each(function() {
+        $(this).request("remove");
+      });
     });
 
     $("body").on("touchstart click", "#brc-request-all", function() {
@@ -289,6 +294,14 @@
           removeSpinner(spinnerContainer);
           modalBody.html(response.data).fadeIn(500);
           $("#brc-request-submit").remove();
+
+          $(".brc-request-single").each(function() {
+            $(this).request("remove");
+          });
+
+          $("#brc-checkout-modal").on('hidden.bs.modal', function() {
+            $(this).replaceWith(response.modalHtml);
+          });
         }
       });
     });

--- a/assets/stylesheets/public.css
+++ b/assets/stylesheets/public.css
@@ -26,6 +26,7 @@
   width: 90px;
   font-size: 10px;
   line-height: 13px;
+  border-radius: 4px !important;
   padding-top: 9px;
   padding-bottom: 9px;
   cursor: pointer;
@@ -41,6 +42,7 @@
 .brc-request-button.brc-cancel {
   background-color: #fff;
   color: #7D807B;
+  margin-right: 7px !important;
 }
 
 .brc-request-button.brc-cancel:hover {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "jbboynton/brochure_request_cpt",
-  "version" : "1.0.2",
+  "version" : "1.0.3",
   "description": "A custom post type for representing brochures and catalogs.",
   "type": "wordpress-plugin",
   "authors": [

--- a/src/classes/RequestAjax.php
+++ b/src/classes/RequestAjax.php
@@ -14,6 +14,7 @@ class RequestAjax {
   private $html = '';
   private $user = '';
   private $request = '';
+  private $modal_html = '';
 
   public function __construct() {
     add_action('wp_ajax_build_modal', array($this, 'build_modal'));
@@ -41,9 +42,11 @@ class RequestAjax {
     $this->request = $_POST['request_data'] ?? array();
 
     $result = $this->mail_request();
+    $this->build_modal_html();
 
     $response = array(
-      'data' => $result
+      'data' => $result,
+      'modalHtml' => $this->modal_html
     );
 
     wp_send_json($response);
@@ -148,5 +151,16 @@ class RequestAjax {
 
     return $result;
   }
+
+  private function build_modal_html() {
+    ob_start();
+
+    include plugin_dir_path(dirname(__FILE__)) .
+      'templates/partials/modal.php';
+    $this->modal_markup = ob_get_contents();
+
+    ob_end_clean();
+  }
+
 }
 

--- a/src/templates/shortcode-brochure.php
+++ b/src/templates/shortcode-brochure.php
@@ -7,6 +7,7 @@
     <div class="brc-row-flex">
       <h1 class="brc-page-title">Brochures &amp; Catalogs</h1>
       <div class="brc-request-all">
+        <button type="button" id="brc-clear-all" class="menu-button brc-request-button brc-cancel">Clear</button>
         <a id="brc-request-all" class="menu-button brc-request-button">Request Print Catalogs <span id="brc-counter" class="badge brc-counter"></span></a>
         <span id="brc-spinner-container"></span>
       </div>


### PR DESCRIPTION
Adds a few features that are difficult to justify not having. These
include:

  - A "Clear All" button, which allows the user to reset their
    selections with one click
  - All selections are cleared after submission, which is expected
    behavior for most users
  - The selection form is reset after submission so the user can
    immediately begin the process again (previously, this resetting only
    occurred after a refresh)