### PR TITLE
Fix clear button bug

### DIFF
--- a/assets/javascripts/requestAjax.js
+++ b/assets/javascripts/requestAjax.js
@@ -109,6 +109,13 @@
       Cookies.set("brc_cart",  cartString);
     }
 
+    function resetCart() {
+      console.log('resetting');
+      var empty = [];
+
+      saveCart(empty);
+    }
+
     function loadCart() {
       $(".brc-request-single").each(function() {
         var brochureId = $(this).data("brochure-id");
@@ -220,6 +227,9 @@
       $(".brc-request-single").each(function() {
         $(this).request("remove");
       });
+
+      resetCart();
+      updateCounter();
     });
 
     $("body").on("touchstart click", "#brc-request-all", function() {
@@ -298,6 +308,9 @@
           $(".brc-request-single").each(function() {
             $(this).request("remove");
           });
+
+          resetCart();
+          updateCounter();
 
           $("#brc-checkout-modal").on('hidden.bs.modal', function() {
             $(this).replaceWith(response.modalHtml);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "jbboynton/brochure_request_cpt",
-  "version" : "1.0.3",
+  "version" : "1.0.4",
   "description": "A custom post type for representing brochures and catalogs.",
   "type": "wordpress-plugin",
   "authors": [

--- a/src/templates/shortcode-brochure.php
+++ b/src/templates/shortcode-brochure.php
@@ -7,7 +7,7 @@
     <div class="brc-row-flex">
       <h1 class="brc-page-title">Brochures &amp; Catalogs</h1>
       <div class="brc-request-all">
-        <button type="button" id="brc-clear-all" class="menu-button brc-request-button brc-cancel">Clear</button>
+        <button type="reset" id="brc-clear-all" class="menu-button brc-request-button brc-cancel">Clear</button>
         <a id="brc-request-all" class="menu-button brc-request-button">Request Print Catalogs <span id="brc-counter" class="badge brc-counter"></span></a>
         <span id="brc-spinner-container"></span>
       </div>


### PR DESCRIPTION
This fixes a bug where the "Clear All" button wouldn't unset brochures
that were not on the current page.