### PR TITLE
Hide 'request' buttons from logged out users

### DIFF
--- a/assets/stylesheets/logged_out.css
+++ b/assets/stylesheets/logged_out.css
@@ -1,0 +1,6 @@
+/* logged_out.css */
+
+.brc-request-all,
+.brc-checkout-modal {
+  display: none;
+}

--- a/src/classes/AdminUI.php
+++ b/src/classes/AdminUI.php
@@ -97,7 +97,7 @@ class AdminUI {
    * file), and then add them below.
    */
   private function find_stylesheets() {
-    return array(
+    $stylesheets = array(
       array(
         Constants::$ADMIN_CSS_ID,
         plugins_url(Constants::$ADMIN_CSS_PATH)
@@ -111,6 +111,15 @@ class AdminUI {
         plugins_url(Constants::$SPINNER_CSS_PATH)
       )
     );
+
+    if (!is_user_logged_in()) {
+      $stylesheets[] = array(
+        Constants::$LOGGED_OUT_CSS_ID,
+        plugins_url(Constants::$LOGGED_OUT_CSS_PATH)
+      );
+    }
+
+    return $stylesheets;
   }
 
   private function enqueue_media() {

--- a/src/classes/Constants.php
+++ b/src/classes/Constants.php
@@ -26,6 +26,10 @@ class Constants {
   public static $PUBLIC_CSS_PATH =
     'brochure_request_cpt/assets/stylesheets/public.css';
 
+  public static $LOGGED_OUT_CSS_ID = 'brc_logged_out_css';
+  public static $LOGGED_OUT_CSS_PATH =
+    'brochure_request_cpt/assets/stylesheets/logged_out.css';
+
   public static $SPINNER_CSS_ID = 'brc_spinner_css';
   public static $SPINNER_CSS_PATH =
     'brochure_request_cpt/assets/stylesheets/spinner.css';


### PR DESCRIPTION
Because:

- Users who are logged out cannot request brochures
- The 'request' buttons is visible to all users, but doesn't work unless
  the user is logged in

This commit:

- Hides the 'request' buttons from logged out users